### PR TITLE
Allow Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ import IPFSKit
 let client: IPFSClient?
     
 public init() {
-    client = try? IPFSClient.init(host: "ipfs.infura.io", port: 5001, ssl: true)
+    client = try? IPFSClient.init(
+        host: "ipfs.infura.io", 
+        port: 5001, 
+        ssl: true, 
+        id: "INFURA-PROJECT-ID", 
+        secret: "INFURA-SECRET"
+    )
 }
 ```
 

--- a/Sources/IPFSKit/HttpIo.swift
+++ b/Sources/IPFSKit/HttpIo.swift
@@ -16,6 +16,7 @@ enum HttpIoError : Error {
 }
 
 public struct HttpIo : NetworkIo {
+    let auth: String
 
     public func receiveFrom(_ source: String, completionHandler: @escaping (Data) throws -> Void) throws {
         guard let url = URL(string: source) else { throw HttpIoError.urlError("Invalid URL") }
@@ -55,7 +56,7 @@ public struct HttpIo : NetworkIo {
     
     public func sendTo(_ target: String, content: Data, completionHandler: @escaping (Data) -> Void) throws {
 
-        var multipart = try Multipart(targetUrl: target, encoding: .utf8)
+        var multipart = try Multipart(targetUrl: target, encoding: .utf8, auth: self.auth)
         multipart = try Multipart.addFilePart(multipart, fileName: nil , fileData: content)
         Multipart.finishMultipart(multipart, completionHandler: completionHandler)
     }
@@ -63,7 +64,7 @@ public struct HttpIo : NetworkIo {
 
     public func sendTo(_ target: String, filePath: String, completionHandler: @escaping (Data) -> Void) throws {
         
-        var multipart = try Multipart(targetUrl: target, encoding: .utf8)
+        var multipart = try Multipart(targetUrl: target, encoding: .utf8, auth: self.auth)
         
         multipart = try handle(oldMultipart: multipart, files: [filePath])
         

--- a/Sources/IPFSKit/Multipart.swift
+++ b/Sources/IPFSKit/Multipart.swift
@@ -23,7 +23,7 @@ public struct Multipart {
     var body = NSMutableData()
     let request: NSMutableURLRequest
 
-    init(targetUrl: String, encoding: String.Encoding) throws {
+    init(targetUrl: String, encoding: String.Encoding, auth: String) throws {
         
         // Eg. UTF8
         self.encoding = encoding
@@ -35,6 +35,7 @@ public struct Multipart {
 
         guard let url = URL(string: targetUrl) else { throw MultipartError.failedURLCreation }
         request = NSMutableURLRequest(url: url)
+	request.addValue("Basic \(auth)", forHTTPHeaderField: "Authorization")
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary="+boundary, forHTTPHeaderField: "content-type")
         request.setValue("Swift IPFS Client", forHTTPHeaderField: "user-agent")


### PR DESCRIPTION
Infura began requiring Basic Auth on August 10, 2022. IPFSClient.init() now takes in the projectId and secret to conform to basic auth.